### PR TITLE
Add ingress definitions

### DIFF
--- a/templates/tonic-integration-test-api-ingress.yaml
+++ b/templates/tonic-integration-test-api-ingress.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "tonic-integration-test-api"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  ingressClassName: {{ .Values.ingress.class }}
+  rules:
+    - host: "{{.Values.prappDetails.name}}-tests.dev.tonic.ai"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: "tonic-integration-test-api"
+                port:
+                  name: "https"

--- a/templates/tonic-integration-test-api-service.yaml
+++ b/templates/tonic-integration-test-api-service.yaml
@@ -3,14 +3,6 @@ kind: Service
 metadata:
   name: tonic-integration-test-api
   namespace: {{ .Release.Namespace }}
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:us-east-1:939426802623:certificate/3c21c3b3-ceb0-4f9b-b803-5bcd5baf5c17"
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "ssl"
-    service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-0213261cea53c795d"
-
   labels:
     app: tonic-integration-test-api
 spec:
@@ -18,7 +10,7 @@ spec:
   - name: "https"
     port: 443
     targetPort: 3600
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: tonic-integration-test-api
 status:

--- a/templates/tonic-web-server-ingress.yaml
+++ b/templates/tonic-web-server-ingress.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "tonic-web-server"
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  ingressClassName: {{ .Values.ingress.class }}
+  rules:
+    - host: "{{.Values.prappDetails.name}}.dev.tonic.ai"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: "tonic-web-server"
+                port:
+                  name: "https"

--- a/templates/tonic-web-server-service.yaml
+++ b/templates/tonic-web-server-service.yaml
@@ -6,12 +6,6 @@ metadata:
 {{- if  ((.Values.tonicai).web_server).annotations }}
   annotations:
     {{- toYaml .Values.tonicai.web_server.annotations | nindent 4 }}
-{{- else }}
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
 {{- end }}
 
   labels:
@@ -21,7 +15,7 @@ spec:
   - name: "https"
     port: 443
     targetPort: 443
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: tonic-web-server
 status:

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -1,3 +1,11 @@
+# information specific to environment generated for a PR
+prappDetails:
+  prNumber:
+  name: 
+
+ingress:
+  class: "nginx"
+
 # tonicdb is the postgres database that will hold information about your workspace.
 tonicdb:
   host: <db-host>
@@ -38,10 +46,6 @@ tonicai:
     image: quay.io/tonicai/tonic_web_server
     # Comma separated list of user emails that should be have the Admin role in Tonic.
     administrators: example@email.com,other@email.com
-    annotations:
-      # This annotation is only required if you are creating an internal facing ELB. Remove this annotation to create public facing ELB.
-      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     features:
       # Enables/Disables the HostIntegrations endpoint
       host_integration_enabled: "true" 


### PR DESCRIPTION
This removes the service kind: LoadBalancer previously used and replaces them with ingress definitions that expose the application and test api through the nginx controller.